### PR TITLE
Version 2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.rappsilberlab</groupId>
     <artifactId>xiFDR</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -170,5 +170,5 @@
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
     <description>Application for FDR estimation cross-linking massspectrometry data </description>
-    <name>xiFDR-2.3.1</name>
+    <name>xiFDR-2.3.2</name>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.rappsilberlab</groupId>
     <artifactId>xiFDR</artifactId>
-    <version>2.3</version>
+    <version>2.3.1</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -170,5 +170,5 @@
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
     <description>Application for FDR estimation cross-linking massspectrometry data </description>
-    <name>xiFDR-2.3</name>
+    <name>xiFDR-2.3.1</name>
 </project>

--- a/src/main/java/org/rappsilber/fdr/CSVinFDR.java
+++ b/src/main/java/org/rappsilber/fdr/CSVinFDR.java
@@ -253,6 +253,7 @@ public class CSVinFDR extends OfflineFDR {
         }
         m_filter.add(filter);
         CsvParser accessionParser = new CsvParser(';', '"');
+        String search_id = csv.getInputFile().getAbsolutePath();
             
 
         Integer crun = getColumn(csv,"run",true);
@@ -592,6 +593,8 @@ public class CSVinFDR extends OfflineFDR {
                 }
                 if (psm.getScore() < minscore)
                     minscore = psm.getScore();
+                
+                psm.setSearchID(search_id);
                 
             }
             if (minscore< 0)

--- a/src/main/java/org/rappsilber/fdr/DB2inFDR.java
+++ b/src/main/java/org/rappsilber/fdr/DB2inFDR.java
@@ -23,6 +23,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
@@ -54,6 +55,7 @@ import org.rappsilber.utils.IntArrayList;
 import org.rappsilber.utils.RArrayUtils;
 import org.rappsilber.utils.SelfAddHashSet;
 import org.rappsilber.utils.Unescape;
+import org.rappsilber.utils.Version;
 import rappsilber.config.DBConnectionConfig;
 import rappsilber.config.RunConfig;
 import rappsilber.gui.components.db.DatabaseProvider;
@@ -66,6 +68,7 @@ import rappsilber.ms.statistics.utils.UpdateableLong;
  public class DB2inFDR extends org.rappsilber.fdr.OfflineFDR implements XiInFDR{
      public static final String summary_marker_long = "%leave_this_here_to_get_the_summary_added_to_the_notes%";
      public static String summary_marker = "%summarys%";
+    private HashMap<String, Version> m_xi_versions = new HashMap<>();
 
     public class Xi2Score {
         int id;
@@ -631,7 +634,13 @@ import rappsilber.ms.statistics.utils.UpdateableLong;
         }
         for (UUID resultset_id : resultset_ids) {
             HashMap<UUID, Xi2Xi1Config> confs = readconfig(resultset_id);
-            m_configs.putAll(confs);
+            for (Map.Entry<UUID, Xi2Xi1Config> confe : confs.entrySet()) {
+                m_configs.put(confe.getKey(), confe.getValue());
+                // TODO need to update ones we have versions in the DB
+                m_xi_versions.put(confe.getKey().toString(), new Version("2.0.beta"));
+            }
+                
+            
             for (Xi2Xi1Config conf :  confs.values()) {
                 this.m_config.add(conf);
             }
@@ -2193,6 +2202,7 @@ import rappsilber.ms.statistics.utils.UpdateableLong;
         pst.addBatch();
     }
     
+     @Override
     public int getxiMajorVersion() {
         return 2;
     }
@@ -2213,6 +2223,17 @@ import rappsilber.ms.statistics.utils.UpdateableLong;
         return this.m_configs.get(search);
     }
 
+    @Override
+    public Version getXiVersion() {
+        if (this.m_xi_versions.size()>0)
+            return this.m_xi_versions.values().iterator().next();
+        return null;
+    }
+
+    @Override
+    public Version getXiVersion(String search) {
+        return this.m_xi_versions.get(search);
+    }
 
 
 }

--- a/src/main/java/org/rappsilber/fdr/XiCSVinFDR.java
+++ b/src/main/java/org/rappsilber/fdr/XiCSVinFDR.java
@@ -29,6 +29,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.rappsilber.data.csv.ColumnAlternatives;
 import org.rappsilber.data.csv.CsvParser;
 import org.rappsilber.data.csv.condition.CsvCondition;
@@ -45,6 +47,8 @@ import org.rappsilber.fdr.utils.MZIdentMLExport;
 import org.rappsilber.fdr.utils.MZIdentMLOwner;
 import org.rappsilber.fdr.utils.MaximisingStatus;
 import org.rappsilber.utils.UpdatableChar;
+import org.rappsilber.utils.Version;
+import rappsilber.config.DBRunConfig;
 import rappsilber.config.RunConfig;
 import rappsilber.config.RunConfigFile;
 import rappsilber.ms.sequence.AminoAcid;
@@ -68,6 +72,9 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
 
     private boolean markModifications;
     private boolean writeMzID = false;
+    private ArrayList<String> m_search_ids = new ArrayList<>();
+    private HashMap<String, RunConfig> m_configs;
+    private HashMap<String, Version> m_xi_versions = new HashMap<>();
 
     private void markVariableModifiedPSMs() {
         HashSet<Peptide> var_mod_peps=new HashSet<>();
@@ -97,6 +104,50 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
         this.writeMzID = b;
     }
 
+    private Version parseVersion(String in_file) {
+        // find the version string in the file name
+        Pattern p = Pattern.compile(".*(?:Xi|xiSEARCH)([0-9](?:\\.[0-9]+(?:\\.[0-9]+)).*)\\.(?-i)(?:csv|tsv|txt)(\\.gz)?$", Pattern.CASE_INSENSITIVE); 
+        Matcher m = p.matcher(in_file);
+        if (m.matches()) {
+            try {
+                return new Version(m.group(1));
+            } catch (Exception e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private void addSearchID(String absolutePath) {
+        this.m_search_ids.add(absolutePath);
+    }
+
+    private void setConfig(String absolutePath, RunConfig conf) {
+        if (m_configs == null) {
+            m_configs = new HashMap<>();
+        }
+        for (rappsilber.ms.crosslinker.CrossLinker cl : conf.getCrossLinker()) {
+            crossLinkerMass.put(cl.getName(), cl.getCrossLinkedMass());
+        }
+        m_configs.put(absolutePath, conf);
+    }
+
+    @Override
+    public Version getXiVersion() {
+        if (this.m_xi_versions.size()>0)
+            return this.m_xi_versions.values().iterator().next();
+        return null;
+    }
+
+    @Override
+    public Version getXiVersion(String absPath) {
+        return m_xi_versions.get(absPath);
+    }
+
+    public void setXiVersion(String absolutePath, Version xiVersion) {
+        this.m_xi_versions.put(absolutePath, xiVersion);
+    }
+    
     class XiSequence extends rappsilber.ms.sequence.Sequence {
         
         public XiSequence(String sequence, RunConfig config) {
@@ -151,12 +202,17 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
     }    
     
     public String argList() {
-        return super.argList() + " --xiconfig=[path to config] --fasta=[path to fasta] --flagModifications --gui --lastowner";
+        return super.argList() + " --xiconfig=[path to config] --xiversion=[version] --fasta=[path to fasta] --flagModifications --gui --lastowner";
     }
     
     public String argDescription() {
         return super.argDescription() + "\n"
                 + "--xiconfig=             what xi config to use to turn find modifications\n"
+                + "                        can be used more themn ones and is applied to all\n"
+                + "                        input files listed after\n"
+                + "--xiversion=            what xiSEARCH version was used\n"
+                + "                        can be used more themn ones and is applied to all\n"
+                + "                        input files listed after)\n"
                 + "--fasta=                fasta file searched"
                 + "--flagModifications     should modified peptide make their own sub-group\n"
                 + "--writemzid             also write out an mzIdentML result file\n"
@@ -172,6 +228,7 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
         argv = super.parseArgs(argv, settings);
         String confpath = null;
         boolean startGUI =  false;
+        String xiVersion = null;
         for (String arg : argv) {
             if (arg.toLowerCase().startsWith("--xiconfig=")) {
                 try {
@@ -192,6 +249,8 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
                     Logger.getLogger(XiCSVinFDR.class.getName()).log(Level.SEVERE, "Error parsing config file:", ex);
                     System.exit(-1);
                 }
+            } else if (arg.toLowerCase().startsWith("--xiversion=")) {
+                xiVersion = arg.substring(arg.indexOf("=") + 1);
             }else if (arg.toLowerCase().contentEquals("--gui")) {
                 startGUI = true;
             }else if (arg.toLowerCase().startsWith("--fasta=")) {
@@ -220,6 +279,12 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
                 setWriteMzID(true);
             }  else {
                unknown.add(arg);
+               if (confpath != null) {
+                   setConfig(arg, getConfig());
+               }
+               if (xiVersion != null) {
+                   setXiVersion(arg, new Version(xiVersion));
+               }
             }
             
         }        
@@ -235,6 +300,7 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
                 fg.setXiConfig(confpath);
             }
             fg.setFDRSettings(settings);
+            fg.setXiVersion(xiVersion);
             
             String outdir = getCsvOutDirSetting();
             String basename = getCsvOutBaseSetting();
@@ -436,14 +502,22 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
 
     @Override
     public RunConfig getConfig(String searchid) {
-        return m_config;
+        if (m_search_ids.size() == 1 && searchid.contentEquals(m_search_ids.get(0))) {
+            return getConfig();
+        }
+        if (m_configs == null) {
+            m_configs = new HashMap<>();
+        }
+        RunConfig ret = m_configs.get(searchid);
+        if (ret == null) {
+            return m_config;
+        }
+        return ret;
     }
 
     @Override
     public ArrayList<String> getSearchIDs() {
-        ArrayList<String> ret = new ArrayList<>(1);
-        ret.add("");
-        return ret;
+        return this.m_search_ids;
     }
 
     @Override
@@ -582,6 +656,32 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
         }
     }
 
+
+    public boolean readCSV(File csv, Version xiVersion) throws FileNotFoundException, IOException, ParseException {
+        boolean ret = this.readCSV(csv);
+        if (xiVersion == null)
+            xiVersion = parseVersion(csv.getAbsolutePath());
+        this.addSearchID(csv.getAbsolutePath());
+        this.setXiVersion(csv.getAbsolutePath(), xiVersion);
+        return ret;
+    }
+
+    public boolean readCSV(CsvParser csv, CsvCondition filter, Version xiVersion, RunConfig conf) throws FileNotFoundException, IOException, ParseException {
+        boolean ret =  this.readCSV(csv, filter);
+        String in_file = csv.getInputFile().getAbsolutePath();
+        if (xiVersion == null)
+            xiVersion = parseVersion(in_file);
+        this.addSearchID(csv.getInputFile().getAbsolutePath());
+        this.setXiVersion(csv.getInputFile().getAbsolutePath(), xiVersion);
+        if (conf != null) {
+            this.setConfig(csv.getInputFile().getAbsolutePath(), conf);
+        } else if (getConfig(in_file) == null && getConfig() != null) {
+            setConfig(in_file, getConfig());
+        }
+        
+        return ret;
+    }
+    
     @Override
     public boolean readCSV(CsvParser csv, CsvCondition filter) throws FileNotFoundException, IOException, ParseException {
         boolean ret = super.readCSV(csv, filter); //To change body of generated methods, choose Tools | Templates.
@@ -590,21 +690,20 @@ public class XiCSVinFDR extends CSVinFDR implements XiInFDR{
         if (markModifications()) {
             markVariableModifiedPSMs();
         }
+        String absPath = csv.getInputFile().getAbsolutePath();
+        if (this.getConfig(absPath) == null) {
+            this.setConfig(absPath, this.getConfig());
+        }
+        Version xiVersion = this.getXiVersion(absPath);
+        if (xiVersion == null) {
+            xiVersion = parseVersion(absPath);
+            setXiVersion(absPath, xiVersion);
+        }
         return ret;
     }
 
     @Override
     public int getxiMajorVersion() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public Xi2Xi1Config getXi2Config() {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
-    }
-
-    @Override
-    public Xi2Xi1Config getXi2Config(String string) {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 

--- a/src/main/java/org/rappsilber/fdr/XiInFDR.java
+++ b/src/main/java/org/rappsilber/fdr/XiInFDR.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.rappsilber.fdr.dataimport.Xi2Xi1Config;
 import org.rappsilber.utils.IntArrayList;
+import org.rappsilber.utils.Version;
 import rappsilber.config.DBRunConfig;
 import rappsilber.config.RunConfig;
 
@@ -26,9 +27,9 @@ public interface XiInFDR {
 
     RunConfig getConfig(String searchid);
     
-    Xi2Xi1Config getXi2Config();
+    Version getXiVersion();
     
-    Xi2Xi1Config getXi2Config(String searchid);
+    Version getXiVersion(String searchid);
 
     public ArrayList<String> getSearchIDs();
 

--- a/src/main/java/org/rappsilber/fdr/XiInFDR.java
+++ b/src/main/java/org/rappsilber/fdr/XiInFDR.java
@@ -7,6 +7,7 @@ package org.rappsilber.fdr;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import org.rappsilber.fdr.dataimport.Xi2Xi1Config;
 import org.rappsilber.utils.IntArrayList;
 import org.rappsilber.utils.Version;
@@ -25,11 +26,14 @@ public interface XiInFDR {
      */
     RunConfig getConfig();
 
+    HashMap<String,? extends RunConfig> getConfigs();
+    
     RunConfig getConfig(String searchid);
     
     Version getXiVersion();
     
     Version getXiVersion(String searchid);
+    HashMap<String,Version> getXiVersions();
 
     public ArrayList<String> getSearchIDs();
 

--- a/src/main/java/org/rappsilber/fdr/gui/FDRGUI.java
+++ b/src/main/java/org/rappsilber/fdr/gui/FDRGUI.java
@@ -86,7 +86,9 @@ import org.rappsilber.peaklist.MgfStyleTitleParser;
 import org.rappsilber.utils.UpdateableInteger;
 import org.rappsilber.utils.XiFDRUtils;
 import org.rappsilber.fdr.dataimport.Xi2Xi1Config;
+import org.rappsilber.utils.Version;
 import rappsilber.config.RunConfigFile;
+import rappsilber.utils.XiVersion;
 
 /**
  *
@@ -528,6 +530,7 @@ public class FDRGUI extends javax.swing.JFrame {
         this.m_result = m_result;
     }
 
+
     private class NeededOptionalComboBoxCellEditor extends DefaultCellEditor {
 
         EditorDelegate neededDelegate;
@@ -875,6 +878,7 @@ public class FDRGUI extends javax.swing.JFrame {
         CsvParser csv = csvs.next();
         String forwardPattern = csvSelect.getForwardPattern();
         String window_title = csv.getInputFile().getName();
+        Version v = csvSelect.getXiVersion();
 
         CSVinFDR ofdr = null;
         if (config != null && fasta != null) {
@@ -883,6 +887,9 @@ public class FDRGUI extends javax.swing.JFrame {
                 ((XiCSVinFDR)ofdr).setConfig(new Xi2Xi1Config(csvSelect.fbConfigIn.getFile()));
             } catch (Exception e){
                 ((XiCSVinFDR)ofdr).setConfig(new RunConfigFile(csvSelect.fbConfigIn.getFile()));
+            }
+            if (v != null) {
+                ((XiCSVinFDR)ofdr).setXiVersion(csv.getInputFile().getAbsolutePath(), v);
             }
             ArrayList<String> fastas = new ArrayList<>(1);
             fastas.add(csvSelect.fbFastaIn.getFile().getAbsolutePath());
@@ -905,6 +912,9 @@ public class FDRGUI extends javax.swing.JFrame {
                     ArrayList<String> fastas = new ArrayList<>(1);
                     fastas.add(csvSelect.fbFastaIn.getFile().getAbsolutePath());
                     ((XiCSVinFDR)nextfdr).setFastas(fastas);
+                    if (v != null) {
+                        ((XiCSVinFDR)ofdr).setXiVersion(csv.getInputFile().getAbsolutePath(), v);
+                    }
                 }else {
                     nextfdr = new CSVinFDR();
                 }
@@ -1606,6 +1616,12 @@ public class FDRGUI extends javax.swing.JFrame {
         fbFolder.setFile(path);
         
     }
+    
+    
+    public void setXiVersion(String xiVersion) {
+        csvSelect.setXiVersion(xiVersion);
+    }
+    
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always

--- a/src/main/java/org/rappsilber/fdr/gui/FDRGUI.java
+++ b/src/main/java/org/rappsilber/fdr/gui/FDRGUI.java
@@ -908,7 +908,11 @@ public class FDRGUI extends javax.swing.JFrame {
 
                 if (config != null && fasta != null) {
                     nextfdr = new XiCSVinFDR();
-                    ((XiCSVinFDR)nextfdr).setConfig(new RunConfigFile(csvSelect.fbConfigIn.getFile()));
+                    try {
+                        ((XiCSVinFDR)nextfdr).setConfig(new Xi2Xi1Config(csvSelect.fbConfigIn.getFile()));
+                    } catch (Exception e){
+                        ((XiCSVinFDR)nextfdr).setConfig(new RunConfigFile(csvSelect.fbConfigIn.getFile()));
+                    }
                     ArrayList<String> fastas = new ArrayList<>(1);
                     fastas.add(csvSelect.fbFastaIn.getFile().getAbsolutePath());
                     ((XiCSVinFDR)nextfdr).setFastas(fastas);

--- a/src/main/java/org/rappsilber/fdr/gui/components/CSVSelection.form
+++ b/src/main/java/org/rappsilber/fdr/gui/components/CSVSelection.form
@@ -532,7 +532,13 @@
                               <Component id="txtForwardColumns" pref="128" max="32767" attributes="0"/>
                           </Group>
                           <Component id="fbFastaIn" max="32767" attributes="0"/>
-                          <Component id="fbConfigIn" max="32767" attributes="0"/>
+                          <Group type="102" attributes="0">
+                              <Component id="fbConfigIn" max="32767" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Component id="txtXiVersion" min="-2" max="-2" attributes="0"/>
+                          </Group>
                       </Group>
                       <EmptySpace min="-2" max="-2" attributes="0"/>
                   </Group>
@@ -545,6 +551,8 @@
                       <Group type="103" groupAlignment="2" attributes="0">
                           <Component id="fbConfigIn" alignment="2" min="-2" max="-2" attributes="0"/>
                           <Component id="jLabel12" alignment="2" min="-2" max="-2" attributes="0"/>
+                          <Component id="txtXiVersion" alignment="2" min="-2" max="-2" attributes="0"/>
+                          <Component id="jLabel4" alignment="2" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="2" attributes="0">
@@ -582,7 +590,7 @@
             </Component>
             <Component class="javax.swing.JLabel" name="jLabel12">
               <Properties>
-                <Property name="text" type="java.lang.String" value="XiConfig"/>
+                <Property name="text" type="java.lang.String" value="xi Config"/>
               </Properties>
             </Component>
             <Component class="javax.swing.JLabel" name="jLabel13">
@@ -637,6 +645,16 @@
               <AuxValues>
                 <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;OfflineFDR.Normalisation&gt;"/>
               </AuxValues>
+            </Component>
+            <Component class="javax.swing.JTextField" name="txtXiVersion">
+              <Properties>
+                <Property name="toolTipText" type="java.lang.String" value="xi version to be written into the mzIdentML file"/>
+              </Properties>
+            </Component>
+            <Component class="javax.swing.JLabel" name="jLabel4">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="xi Version"/>
+              </Properties>
             </Component>
           </SubComponents>
         </Container>

--- a/src/main/java/org/rappsilber/fdr/gui/components/SingleTextValueNumericSpinner.java
+++ b/src/main/java/org/rappsilber/fdr/gui/components/SingleTextValueNumericSpinner.java
@@ -62,7 +62,7 @@ public class SingleTextValueNumericSpinner extends javax.swing.JSpinner {
             this.stepSize = stepSize;
         }
         public <T>AmbiguitySpinnerModel() {
-            this(Integer.valueOf(0), new Integer(0), null, Integer.valueOf(1));
+            this(0, 0, null, 1);
         }
         
         public Object getValue() {

--- a/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
+++ b/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
@@ -469,8 +469,9 @@ public class MZIdentMLExport {
         HashMap<ProteinGroup, ProteinAmbiguityGroup> pg2Pag = new HashMap<ProteinGroup, ProteinAmbiguityGroup>();
         List<ProteinAmbiguityGroup> pagList = proteinDetectionList.getProteinAmbiguityGroup();
         int pagID =0;
-
-        handleAnalysisSoftware(OfflineFDR.getXiFDRVersion().toString());
+        
+        if (OfflineFDR.getXiFDRVersion().toString() != null)
+            handleAnalysisSoftware(OfflineFDR.getXiFDRVersion().toString(), (XiInFDR)fdr);
         handleAuditCollection(owner.first, owner.last, owner.email, owner.address, owner.org);
         handleProvider();                //Performed after auditcollection, since contact is needed for provider
 
@@ -1521,7 +1522,7 @@ public class MZIdentMLExport {
      * </SoftwareName>
      *
      */
-    public void handleAnalysisSoftware(String version) {
+    public void handleAnalysisSoftware(String version, XiInFDR fdr) {
         analysisSoftwareList = new AnalysisSoftwareList();
         List<AnalysisSoftware> analysisSoftwares = analysisSoftwareList.getAnalysisSoftware();
         analysisSoftware = new AnalysisSoftware();
@@ -1532,6 +1533,7 @@ public class MZIdentMLExport {
         // TODO need to ask for version/software - or get from cmd param
         p.setParam(makeCvParam("MS:1002544","xi",psiCV));
         analysisSoftware.setSoftwareName(p);
+        analysisSoftware.setVersion(fdr.getXiVersion().toString());
 
         analysisSoftwares.add(analysisSoftware);
 

--- a/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
+++ b/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
@@ -590,7 +590,6 @@ public class MZIdentMLExport {
             // Get the next spectrum.
 //            Spectrum spectrum = iter.next();
             PSM f = psms.get(0);
-            boolean passed = result.psmFDR.filteredContains(f) || ( f.getPartOfUniquePSM() != null && f.getPartOfUniquePSM() == f && result.psmFDR.filteredContains(f.getPartOfUniquePSM()));
             int spectrumNumber = Integer.parseInt(f.getScan());//note: spectrum number seems to be a sequential index. For the spectrum number as found in xtandem file use spectrumId
             String run = f.getRun();
 
@@ -614,7 +613,9 @@ public class MZIdentMLExport {
             HashMap<String, SpectrumIdentificationItem> sIIMap = new HashMap<String, SpectrumIdentificationItem>();
             HashSet<org.rappsilber.fdr.entities.Peptide> allPeps = new HashSet<org.rappsilber.fdr.entities.Peptide>();
             HashMap<String,SpectraData> runData = new HashMap<String,SpectraData>();
+            boolean firstSpecPSM = true;
             for (PSM psm : psms) {
+                boolean passed = result.psmFDR.filteredContains(psm) || (psm.getPartOfUniquePSM() != null && psm.getPartOfUniquePSM() == psm && result.psmFDR.filteredContains(psm.getPartOfUniquePSM()));
                 xlModId++;
                 org.rappsilber.fdr.entities.PeptidePair peppair = psm.getPeptidePair();
                 
@@ -933,11 +934,15 @@ public class MZIdentMLExport {
                     }
                 }
 
-                specIdentRes.setSpectrumID(this.scanIDTranslation.getID(f));
-                specIdentRes.setId("SIR_" + sirCounter);
-                specIdentRes.setSpectraData(specData);
+                if (firstSpecPSM) {
+                    specIdentRes.setSpectrumID(this.scanIDTranslation.getID(f));
+                    specIdentRes.setId("SIR_" + sirCounter);
+                    specIdentRes.setSpectraData(specData);
+
+                    specIdentRes.getCvParam().add(makeCvParam("MS:1000797", "peak list scans", psiCV,psm.getScan()+""));
+                    firstSpecPSM = false;
+                }
                 
-                specIdentRes.getCvParam().add(makeCvParam("MS:1000797", "peak list scans", psiCV,psm.getScan()+""));
 
                 {
                     

--- a/src/main/resources/xifdrproject.properties
+++ b/src/main/resources/xifdrproject.properties
@@ -1,10 +1,12 @@
 xifdr.version=${project.version}
 xifdr.artifactId=${project.artifactId}
 xifdr.changelog=\
+2.3.2\n\
+* Bugfix: shared topranking matches, validation status was only checked for first one\n\
 2.3.1\n\
 * Support for writing xiSEARCH version to mzIdentML\n\
   * versions can be defined by --xiversion= argument or in the GUI - but if not given it will be guessed from the xiSEARCH result file name\n\
-  * limitation currently only the xiVersion associated with the first input file is forwarded to mzIdentML\n\
+  * limitation: currently only the xiVersion associated with the first input file is forwarded to mzIdentML\n\
 * CSV input permits different xiSEARCH configs to be associated with input different files (also mainly relevant for mzIdentML export)  \n\
 2.3\n\
 * xiSEARCH2 mzIdentML support\n\
@@ -118,23 +120,23 @@ BugFix for reading from instable db connections\n\
 * Boosting happens in two steps if additional columns for boosting are used\n\
 1.4.1\n\
 * Some cleavable cross-linker related columns are read in\n\
-** specific grouping for these can be selected\n\
+  * specific grouping for these can be selected\n\
 * BugFix for spaces in ambiguous accession list\n\
 * Validity check disabled by default  but still reports warning\n\
 * Validity check warnings more verbose\n\
 * When writing csv-files from the command line mzIdentML files get written out as well\n\
-** a window asking for document-owner will be displayed\n\
+  * a window asking for document-owner will be displayed\n\
 * decoy:psms better marked\n\
 * Improved synchronisation between settings-panel\n\
 * Some adaptation to forward settings from the command-line to the GUI\n\
 1.4.0\n\
 * Medium complexity level of FDR interface replaces (previous simple one)\n\
 * Some cleavable cross-linker related columns are read in\n\
-** specific grouping for these can be selected\n\
+  * specific grouping for these can be selected\n\
 * Validity check disabled by default  but still reports warning\n\
 * Validity check warnings more verbose\n\
 * When writing csv-files from the command line mzIdentML files get writen out as well\n\
-** a window asking for document-owner will be displayed\n\
+  * a window asking for document-owner will be displayed\n\
 * decoy:psms better marked\n\
 * Improved synchronisation between settings-panel\n\
 * Some adaptation to forward settings from the command-line to the GUI\n\
@@ -157,7 +159,7 @@ BugFix for reading from instable db connections\n\
 * support for local FDR (PEP)\n\
 * will read in and try to boost on delta score and peptide coverage\n\
 * searches can be normalized by a version of an interpolated PSM-FDR\n\
-** mainly useful for combining searches that have different score-ranges\n\
+  * mainly useful for combining searches that have different score-ranges\n\
 * using fastutil to reduce some memory requirements\n\
 * support for directional crosslinker has been (partially) removed\n\
 * bugfix for automatic recognition of column-names from command-line version \n\
@@ -181,8 +183,8 @@ BugFix for reading from instable db connections\n\
 * peptide-files contain the peptide positions\n\
 1.1.26 \n\
 * two new columns for CSV-import\n\
-** filescanindex\n\
-** matchrank\n\
+  * filescanindex\n\
+  * matchrank\n\
 1.1.25 \n\
 * BugFix csv-import\n\
 1.1.24 \n\

--- a/src/main/resources/xifdrproject.properties
+++ b/src/main/resources/xifdrproject.properties
@@ -1,6 +1,11 @@
 xifdr.version=${project.version}
 xifdr.artifactId=${project.artifactId}
 xifdr.changelog=\
+2.3.1\n\
+* Support for writing xiSEARCH version to mzIdentML\n\
+  * versions can be defined by --xiversion= argument or in the GUI - but if not given it will be guessed from the xiSEARCH result file name\n\
+  * limitation currently only the xiVersion associated with the first input file is forwarded to mzIdentML\n\
+* CSV input permits different xiSEARCH configs to be associated with input different files (also mainly relevant for mzIdentML export)  \n\
 2.3\n\
 * xiSEARCH2 mzIdentML support\n\
 2.2.5\n\


### PR DESCRIPTION
* Bugfix: shared topranking matches, validation status was only checked for first one
Version 2.3.1
* Support for writing xiSEARCH version to mzIdentML\n\
  * versions can be defined by --xiversion= argument or in the GUI - but if not given it will be guessed from the xiSEARCH result file name\n\
  * limitation currently only the xiVersion associated with the first input file is forwarded to mzIdentML\n\
* CSV input permits different xiSEARCH configs to be associated with input different files (also mainly relevant for mzIdentML export)  \n\