### PR TITLE
Version 2.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.rappsilberlab</groupId>
     <artifactId>xiFDR</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -170,5 +170,5 @@
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
     <description>Application for FDR estimation cross-linking massspectrometry data </description>
-    <name>xiFDR-2.3.2</name>
+    <name>xiFDR-2.3.3</name>
 </project>

--- a/src/main/resources/xifdrproject.properties
+++ b/src/main/resources/xifdrproject.properties
@@ -1,6 +1,10 @@
 xifdr.version=${project.version}
 xifdr.artifactId=${project.artifactId}
 xifdr.changelog=\
+2.3.3\n\
+* Write out the highest CSM score for each raw-file also into the PPI result file\n\
+* BugFix: if several csv-files where read in only the highest score for raw files\n\
+   found in one of the source CSV files got reported in the peptide pair and residue pair result files\n\
 2.3.2\n\
 * Bugfix: shared topranking matches, validation status was only checked for first one\n\
 2.3.1\n\


### PR DESCRIPTION
* Write out the highest CSM score for each raw-file also into the PPI result file
* BugFix: if several csv-files where read in only the highest score for raw files found in one of the source CSV files got reported in the peptide pair and residue pair result files