### PR TITLE
Version 2.3.9

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,10 @@
 
+2.3.9
+
+* Write out mzIdentML crosslinker stub information to donor and acceptor
+* no need to restart anymore - should produce valid UTF-8 mzIdentML without it
+* db reading fix for large scan_ids
+
 2.3.8
 
 * Write out crosslinker stub information to mzIdentML

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.rappsilberlab</groupId>
     <artifactId>xiFDR</artifactId>
-    <version>2.3.8</version>
+    <version>2.3.9</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -114,6 +114,21 @@
             <artifactId>XLMOD</artifactId>
             <version>1.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
     <build>
 	<plugins>
@@ -170,5 +185,5 @@
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
     <description>Application for FDR estimation cross-linking massspectrometry data </description>
-    <name>xiFDR-2.3.8</name>
+    <name>xiFDR-2.3.9</name>
 </project>

--- a/src/main/java/org/rappsilber/fdr/CommandLine.java
+++ b/src/main/java/org/rappsilber/fdr/CommandLine.java
@@ -147,7 +147,7 @@ public class CommandLine {
         boolean csv = false;
         boolean gui = true;
         boolean db = false;
-        boolean dorestart=true;
+        boolean dorestart=false;
 
         for (String a : args) {
             if (a.startsWith("--xiconfig=") || a.contentEquals("--gui")) {

--- a/src/main/java/org/rappsilber/fdr/DBinFDR.java
+++ b/src/main/java/org/rappsilber/fdr/DBinFDR.java
@@ -1052,7 +1052,7 @@ public class DBinFDR extends org.rappsilber.fdr.OfflineFDR implements XiInFDR {
                     double pep1mass = rs.getDouble(pep1massColumn);
                     double pep2mass = rs.getDouble(pep2massColumn);
                     int search_id = rs.getInt(search_idColumn);
-                    int scan_id = rs.getInt(spectrum_idColumn);
+                    long scan_id = rs.getLong(spectrum_idColumn);
                     if (pepSeq2 != null && pepSeq2.matches("^X-?[0-9\\.]*$")) {
                         double mass = Double.parseDouble(pepSeq2.substring(1));
                         AminoModification am = new AminoModification(pepSeq2, AminoAcid.A, mass-18.0105647);
@@ -1954,7 +1954,7 @@ public class DBinFDR extends org.rappsilber.fdr.OfflineFDR implements XiInFDR {
 
     }
 
-    protected PSM setUpDBPSM(String psmID, String run, String scan, long pep1ID, long pep2ID, String pepSeq1, String pepSeq2, int peplen1, int peplen2, int site1, int site2, boolean isDecoy1, boolean isDecoy2, int charge, double score, long protein1ID, String accession1, String description1, long protein2ID, String accession2, String description2, int pepPosition1, int pepPosition2, String sequence1, String sequence2, double peptide1score, double peptide2score, int spectrum_charge, String xl, double pmz, double calc_mass, double pep1mass, double pep2mass, int search_id, int scan_id) {
+    protected PSM setUpDBPSM(String psmID, String run, String scan, long pep1ID, long pep2ID, String pepSeq1, String pepSeq2, int peplen1, int peplen2, int site1, int site2, boolean isDecoy1, boolean isDecoy2, int charge, double score, long protein1ID, String accession1, String description1, long protein2ID, String accession2, String description2, int pepPosition1, int pepPosition2, String sequence1, String sequence2, double peptide1score, double peptide2score, int spectrum_charge, String xl, double pmz, double calc_mass, double pep1mass, double pep2mass, int search_id, long scan_id) {
         PSM psm = addMatch(psmID, run, scan, pep1ID, pep2ID, pepSeq1, pepSeq2, peplen1, peplen2, site1, site2, isDecoy1, isDecoy2, charge, score, protein1ID, accession1, description1, protein2ID, accession2, description2, pepPosition1, pepPosition2, sequence1, sequence2, peptide1score, peptide2score, spectrum_charge == -1?"Unknow Charge" : null, xl);
         if (spectrum_charge == -1) {
             psm.setNegativeGrouping(" UnknownCharge");
@@ -1998,7 +1998,7 @@ public class DBinFDR extends org.rappsilber.fdr.OfflineFDR implements XiInFDR {
 //            Logger.getLogger(this.getClass().getName()).log(Level.WARNING, "wrong mass");
 //        }
         psm.setSearchID(Integer.toString(search_id));
-        psm.setScanID(Integer.toString(scan_id));
+        psm.setScanID(Long.toString(scan_id));
         return psm;
 //                    if (!psm.isLinear()) {
 //                        psm.setCrosslinker(rs.getString(xlColumn));

--- a/src/main/java/org/rappsilber/fdr/entities/PSM.java
+++ b/src/main/java/org/rappsilber/fdr/entities/PSM.java
@@ -663,7 +663,7 @@ public class PSM extends AbstractFDRElement<PSM> {
      */
     public void setFDRGroup() {
         
-        fdrGroup = PeptidePair.getFDRGroup(peptide1, peptide2, isLinear(), isInternal, this.getNegativeGrouping(), getPositiveGrouping(),isNonCovalent ? "NonCovalent":"");
+        fdrGroup = PeptidePair.getFDRGroup(peptide1, peptide2, isLinear(), isInternal, this.getNegativeGrouping(), getPositiveGrouping(),isNonCovalent ? "NonCovalent":"");        
         String ag = RArrayUtils.toString(getAdditionalFDRGroups(), " ");
         if (!ag.isEmpty())
             fdrGroup = ag + " " + fdrGroup;

--- a/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
+++ b/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
@@ -750,6 +750,7 @@ public class MZIdentMLExport {
                                 xlModParam.setCv(psiCV);
                                 xlModParam.setValue(Integer.toString(xlModId));
                                 mod.getCvParam().add(xlModParam);
+                                mod.getCvParam().addAll(stubs);
                                 mzidPep.getModification().add(mod);
                                 link = pp.getPeptideLinkSite(pi+1);
                                 mod = getCrosslinkerReceptorModification(link, 0, fragmentIsMono);
@@ -759,6 +760,7 @@ public class MZIdentMLExport {
                                 xlModParam.setCv(psiCV);
                                 xlModParam.setValue(Integer.toString(xlModId));
                                 mod.getCvParam().add(xlModParam);
+                                mod.getCvParam().addAll(stubs);
                                 mod.getCvParam().addAll(stubs);
                                 mzidPep.getModification().add(mod);
                             }
@@ -772,6 +774,7 @@ public class MZIdentMLExport {
                                 xlModParam.setCv(psiCV);
                                 xlModParam.setValue(Integer.toString(xlModId));
                                 mod.getCvParam().add(xlModParam);
+                                mod.getCvParam().addAll(stubs);
                                 mzidPep.getModification().add(mod);
                             }
                         }
@@ -2410,6 +2413,7 @@ public class MZIdentMLExport {
         }
         searchMod.getCvParam().add(modParam);
         searchMod.getCvParam().addAll(stubs);
+        searchModAcceptor.getCvParam().addAll(stubs);
         
         if (crosslinker instanceof rappsilber.ms.crosslinker.AminoAcidRestrictedCrossLinker) {
             HashSet<String> modsRes = new HashSet<>();
@@ -2479,6 +2483,7 @@ public class MZIdentMLExport {
             searchModCTermAcceptor.getResidues().add(".");
             searchModCTermAcceptor.getSpecificityRules().add(sr);
             searchModCTermAcceptor.getCvParam().add(makeCvParam(getCrosslinkedAcceptorModAcc(), crosslinkedAcceptorModName, psiCV, ""+countCrossLinker));
+            searchModCTermAcceptor.getCvParam().addAll(stubs);
             ret.add(searchModCTermAcceptor);
         }
 
@@ -2501,6 +2506,7 @@ public class MZIdentMLExport {
             searchModNTermAcceptor.getResidues().add(".");
             searchModNTermAcceptor.getSpecificityRules().add(sr);
             searchModNTermAcceptor.getCvParam().add(makeCvParam(getCrosslinkedAcceptorModAcc(), crosslinkedAcceptorModName, psiCV, ""+countCrossLinker));
+            searchModNTermAcceptor.getCvParam().addAll(stubs);
             ret.add(searchModNTermAcceptor);
         }
         

--- a/src/main/resources/xifdrproject.properties
+++ b/src/main/resources/xifdrproject.properties
@@ -1,6 +1,10 @@
 xifdr.version=${project.version}
 xifdr.artifactId=${project.artifactId}
 xifdr.changelog=\
+2.3.9\n\
+* Write out mzIdentML crosslinker stub information to donor and acceptor\n\
+* no need to restart anymore - should produce valid UTF-8 mzIdentML without it\n\
+* db reading fix for large scan_ids
 2.3.8\n\
 * Write out crosslinker stub information to mzIdentML\n\
 * updated to XLMOD java library 1.1 to reduce "unknown modifications"\n\


### PR DESCRIPTION
* Write out mzIdentML crosslinker stub information to donor and acceptor
* no need to restart anymore - should produce valid UTF-8 mzIdentML without it
* db reading fix for lareg scan_ids