### PR TITLE
Version 2.4.1: fix output extension handling, default GUI to self+between boosting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,10 @@
 
+2.4.1
+
+* Enforce tsv/txt/csv extension for write out of results
+* GUI now defaults to self+between boosting
+* BugFix: csv.getDouble() was initialised with int value
+
 2.4
 
 * Self and heteromeric matches can now boosted sequentially and (mostly) independently

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.rappsilberlab</groupId>
     <artifactId>xiFDR</artifactId>
-    <version>2.4</version>
+    <version>2.4.1</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -227,5 +227,5 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
     <description>Application for FDR estimation cross-linking massspectrometry data </description>
-    <name>xiFDR-2.4</name>
+    <name>xiFDR-2.4.1</name>
 </project>

--- a/src/main/java/org/rappsilber/fdr/CSVinFDR.java
+++ b/src/main/java/org/rappsilber/fdr/CSVinFDR.java
@@ -375,7 +375,7 @@ public class CSVinFDR extends OfflineFDR {
                         if (c > 0 || (c==0 && site1 > site2) ) {
                             key=key +" P1_" + csv.getValue(cpep1) + " P2_" + csv.getValue(cpep2) + " " + (int)csv.getDouble(cpep1site) + " " + (int)csv.getDouble(cpep2site);
                         } else {
-                            key=key +" P1_" + csv.getValue(cpep2) + " P2_" + csv.getValue(cpep1) + " " + (int)csv.getDouble(cpep2site) + " " + (int)csv.getDouble(cpep1site);;
+                            key=key +" P1_" + csv.getValue(cpep2) + " P2_" + csv.getValue(cpep1) + " " + (int)csv.getDouble(cpep2site) + " " + (int)csv.getDouble(cpep1site);
                         }
                         //psmID = PSMIDs.toIntValue(key);
                         psmID = key;
@@ -398,7 +398,7 @@ public class CSVinFDR extends OfflineFDR {
                         peplen2 = pepSeq2.replaceAll("[^A-Z]", "").length();
                     }
                 else {
-                    peplen2 = (int)csv.getDouble(cpep2len, 0);
+                    peplen2 = (int)csv.getDouble(cpep2len, 0.0);
                 }
 
                 boolean isDecoy1 = csv.getBool(cpep1decoy,false);

--- a/src/main/java/org/rappsilber/fdr/FDRSettingsImpl.java
+++ b/src/main/java/org/rappsilber/fdr/FDRSettingsImpl.java
@@ -33,7 +33,7 @@ public class FDRSettingsImpl implements FDRSettings {
     double ProteinGroupLinkFDR = 0.05;
     double ProteinGroupPairFDR = 1;
     int BoostingSteps = 4;
-    FDRSettings.BoostMode boostMode = FDRSettings.BoostMode.NONE;
+    FDRSettings.BoostMode boostMode = FDRSettings.BoostMode.SELFBETWEEN;
     FDRSettings.CrosslinkType crosslinkTypeFilter = FDRSettings.CrosslinkType.ALL;
     boolean LinkDirectional;
     boolean PPIDirectional;

--- a/src/main/java/org/rappsilber/fdr/OfflineFDR.java
+++ b/src/main/java/org/rappsilber/fdr/OfflineFDR.java
@@ -1951,7 +1951,7 @@ public abstract class OfflineFDR {
             String header = csvFormater.valuesToString(getPSMHeader());
             try {
                 xiviewOut = new PrintWriter(xiviewName, csvcharset.name());
-                xiviewOut.println(getXiViewHeader());
+                xiviewOut.println(csvFormater.valuesToString(getXiViewHeader()));
                 psmOut = new PrintWriter(outName, csvcharset.name());
                 psmOut.println(header);
                 psmLinearOut = new PrintWriter(outNameLinear, csvcharset.name());
@@ -3812,6 +3812,7 @@ public abstract class OfflineFDR {
         int fdrDigits = commandlineFDRDigits;
         FDRLevel maximizeWhat = null;
         settings.doOptimize(null);
+        settings.setBoostMode(FDRSettings.BoostMode.NONE);
 
         for (String arg : argv) {
 

--- a/src/main/java/org/rappsilber/fdr/gui/FDRGUI.java
+++ b/src/main/java/org/rappsilber/fdr/gui/FDRGUI.java
@@ -382,10 +382,18 @@ public class FDRGUI extends javax.swing.JFrame {
                 setting = true;
                 String filename = fbFolder.getText();
                 setCsvOut(XiFDRUtils.splitFilename(filename));
-                if (getCsvOut().tsv)
+                XiFDRUtils.FDRCSVOUT co = getCsvOut();
+                if (co.tsv)
                     rbTSV.setSelected(true);
-                if (getCsvOut().tsv)
+                else if (co.csv)
                     rbCSV.setSelected(true);
+                else if (rbCSV.isSelected()) {
+                    co.basename += co.extension;
+                    co.extension = ".csv";
+                } else if (rbTSV.isSelected()) {
+                    co.basename += co.extension;
+                    co.extension = ".tsv";
+                }
 
                 fbFolder.setFile(getCsvOut().folder + File.separator + getCsvOut().basename + getCsvOut().extension);
                 setting = false;

--- a/src/main/resources/xifdrproject.properties
+++ b/src/main/resources/xifdrproject.properties
@@ -1,6 +1,10 @@
 xifdr.version=${project.version}
 xifdr.artifactId=${project.artifactId}
 xifdr.changelog=\
+2.4.1\n\
+* Enforce tsv/txt/csv extension for write out of results\n\
+* GUI now defaults to self+between boosting\n\
+* BugFix: csv.getDouble() was initialised with int value\n\
 2.4\n\
 * Self and heteromeric matches can now boosted sequentially and (mostly) independently\n\
 * Protein homomultimeric self links are now treated separately\n\


### PR DESCRIPTION


 - CSV/TSV output-extension falls back to coercing the extension from  the selected radio button for unrecognized/missing extensions.
 - Fix xiFDR-CSV input: csv.getDouble() default value was passed as an int instead of a double.
 - Fix xiview CSV export: header line now goes through the CSV formatter like the other output headers.
 - Default GUI boost mode to self+between; CLI keeps its prior no-boost default via explicit parseArgs override.